### PR TITLE
Require parens in arrow function arguments

### DIFF
--- a/index.js
+++ b/index.js
@@ -119,7 +119,7 @@ module.exports = {
     'spaced-comment': 2,
     'wrap-regex': 2,
     'arrow-body-style': 2,
-    'arrow-parens': [2, 'always'],
+    'arrow-parens': [2, 'as-needed'],
     'arrow-spacing': 2,
     'constructor-super': 2,
     'generator-star-spacing': 2,

--- a/index.js
+++ b/index.js
@@ -119,7 +119,7 @@ module.exports = {
     'spaced-comment': 2,
     'wrap-regex': 2,
     'arrow-body-style': 2,
-    'arrow-parens': [2, 'as-needed'],
+    'arrow-parens': [2, 'always'],
     'arrow-spacing': 2,
     'constructor-super': 2,
     'generator-star-spacing': 2,


### PR DESCRIPTION
After accidentally commiting this change to master for 2 times because GitHub's _Create a new branch for this commit and start a pull request_ function is broken, here's the proposal to always enforce parens in arrow function arguments.

**Why?** There are three cases:
- `({ a }) => a`
- `(a, b) => a + b`
- `a => a`

It feels unnatural that single argument functions with decomposition require parens but regular single argument functions do not. Also, I have often encountered the case where I had to add or remove parens because the method signature changed or I didn't require the second argument, which happens mostly in callback methods.
